### PR TITLE
Add more functions to the Corsair CUESDK class

### DIFF
--- a/sdk/src/main/java/io/rcw/chromajdk/sdk/DeviceManager.java
+++ b/sdk/src/main/java/io/rcw/chromajdk/sdk/DeviceManager.java
@@ -1,9 +1,30 @@
 package io.rcw.chromajdk.sdk;
 
+import io.rcw.chromajdk.sdk.internals.InternalDeviceManager;
+
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 public interface DeviceManager {
+
+    Function<ChromaConfiguration, DeviceManager> instance = new Function<ChromaConfiguration, DeviceManager>() {
+        private DeviceManager instance;
+
+        @Override
+        public DeviceManager apply(ChromaConfiguration configuration) {
+            if (instance == null) {
+                (instance = new InternalDeviceManager(configuration)).initialize();
+            }
+            return instance;
+        }
+    };
+
+    static DeviceManager getInstance(ChromaConfiguration configuration) {
+        return instance.apply(configuration);
+    }
+
+
     void initialize();
 
     Optional<List<ChromaDevice>> devicesByBrand(Brand brand);

--- a/sdk/src/main/java/io/rcw/chromajdk/sdk/Test.java
+++ b/sdk/src/main/java/io/rcw/chromajdk/sdk/Test.java
@@ -1,7 +1,6 @@
 package io.rcw.chromajdk.sdk;
 
 import io.rcw.chromajdk.sdk.effects.custom.ChromaFlashEffect;
-import io.rcw.chromajdk.sdk.internals.InternalDeviceManager;
 
 import java.awt.Color;
 import java.util.Arrays;
@@ -10,11 +9,8 @@ import java.util.concurrent.TimeUnit;
 public class Test {
 
     public static void main(String[] args) {
-        final ChromaFlashEffect effect = new ChromaFlashEffect(Arrays.asList(Color.RED, Color.GREEN, Color.BLUE, Color.YELLOW, Color.MAGENTA), 250, TimeUnit.MILLISECONDS);
-
-        final DeviceManager deviceManager = new InternalDeviceManager(ChromaConfiguration.defaultConfiguration());
-
-        deviceManager.initialize();
+        final ChromaFlashEffect effect = new ChromaFlashEffect(Arrays.asList(Color.RED, Color.GREEN, Color.BLUE, Color.YELLOW, Color.MAGENTA), 1, TimeUnit.SECONDS);
+        final DeviceManager deviceManager = DeviceManager.getInstance(ChromaConfiguration.defaultConfiguration());
 
         if (deviceManager.hasDevice(Brand.RAZER)) {
             System.out.println("Has razer devices");
@@ -24,7 +20,9 @@ public class Test {
             System.out.println("Has corsair devices");
         }
 
-        deviceManager.devicesByType(DeviceType.KEYBOARD).ifPresent(list -> list.forEach(device -> device.setEffect(effect)));
+        deviceManager.devicesByType(DeviceType.KEYBOARD).ifPresent(list -> list.forEach(device -> {
+            device.setEffect(effect);
+        }));
 
         while (true) {
         }

--- a/sdk/src/main/java/io/rcw/chromajdk/sdk/internals/corsair/CorsairChromaSDK.java
+++ b/sdk/src/main/java/io/rcw/chromajdk/sdk/internals/corsair/CorsairChromaSDK.java
@@ -43,14 +43,17 @@ public final class CorsairChromaSDK extends AbstractChromaSDK {
                         );
                     }
 
-                    this.setColors(corsairLedColors);
+                    this.setColors(i, corsairLedColors);
                 }
             }
         }
     }
 
-    public void setColors(List<CorsairLedColor> colors) {
-        nativeCUESDK.CorsairSetLedsColors(colors.size(), this.writeArray(colors));
+    public void setColors(int deviceIndex, List<CorsairLedColor> colors) {
+        nativeCUESDK.CorsairSetLedsColorsFlushBuffer();
+        nativeCUESDK.CorsairSetLedsColorsBufferByDeviceIndex(deviceIndex, colors.size(), this.writeArray(colors));
+
+        nativeCUESDK.CorsairSetLedsColorsFlushBuffer();
     }
 
     private CorsairLedColor.CorsairLedColorStructure writeArray(List<CorsairLedColor> corsairLedColors) {

--- a/sdk/src/main/java/io/rcw/chromajdk/sdk/internals/corsair/CorsairChromaSDK.java
+++ b/sdk/src/main/java/io/rcw/chromajdk/sdk/internals/corsair/CorsairChromaSDK.java
@@ -50,10 +50,8 @@ public final class CorsairChromaSDK extends AbstractChromaSDK {
     }
 
     public void setColors(int deviceIndex, List<CorsairLedColor> colors) {
-        nativeCUESDK.CorsairSetLedsColorsFlushBuffer();
         nativeCUESDK.CorsairSetLedsColorsBufferByDeviceIndex(deviceIndex, colors.size(), this.writeArray(colors));
-
-        nativeCUESDK.CorsairSetLedsColorsFlushBuffer();
+        nativeCUESDK.CorsairSetLedsColorsFlushBufferAsync(null, null);
     }
 
     private CorsairLedColor.CorsairLedColorStructure writeArray(List<CorsairLedColor> corsairLedColors) {

--- a/sdk/src/main/java/io/rcw/chromajdk/sdk/internals/jna/corsair/NativeCUESDK.java
+++ b/sdk/src/main/java/io/rcw/chromajdk/sdk/internals/jna/corsair/NativeCUESDK.java
@@ -3,7 +3,6 @@ package io.rcw.chromajdk.sdk.internals.jna.corsair;
 import com.sun.jna.Callback;
 import com.sun.jna.Library;
 import com.sun.jna.Pointer;
-import com.sun.jna.Structure;
 import io.rcw.chromajdk.sdk.internals.corsair.device.CorsairDeviceInfo;
 import io.rcw.chromajdk.sdk.internals.corsair.led.CorsairLedColor;
 import io.rcw.chromajdk.sdk.internals.jna.corsair.led.CorsairLedPositions;
@@ -88,6 +87,11 @@ public interface NativeCUESDK extends Library {
      */
     byte CorsairSetLedsColorsAsync(int size, CorsairLedColor.CorsairLedColorStructure ledsColors, NativeCUESDK.CorsairSetLedsColorsAsync_CallbackType_callback CallbackType, Pointer context);
 
+
+    byte CorsairSetLedsColorsBufferByDeviceIndex(int deviceIndex, int size, CorsairLedColor.CorsairLedColorStructure ledsColors);
+
+    byte CorsairSetLedsColorsFlushBuffer();
+
     /**
      * Original signature : <code>int CorsairGetDeviceCount()</code><br>
      * <i>native declaration : line 128</i>
@@ -106,7 +110,7 @@ public interface NativeCUESDK extends Library {
      */
     CorsairLedPositions CorsairGetLedPositions();
 
-    CorsairLedPositions CorsairGetLedPositionsByDeviceIndex( int deviceIndex );
+    CorsairLedPositions CorsairGetLedPositionsByDeviceIndex(int deviceIndex);
 
     /**
      * Original signature : <code>CorsairLedId CorsairGetLedIdForKeyName(char)</code><br>

--- a/sdk/src/main/java/io/rcw/chromajdk/sdk/internals/jna/corsair/NativeCUESDK.java
+++ b/sdk/src/main/java/io/rcw/chromajdk/sdk/internals/jna/corsair/NativeCUESDK.java
@@ -73,6 +73,11 @@ public interface NativeCUESDK extends Library {
         void apply(Pointer voidPtr1, byte bool1, int CorsairError1);
     }
 
+
+    public interface CorsairSetLedsColorsFlushBufferAsync_callback_callback extends Callback {
+        void apply(Pointer context, byte result, int error);
+    }
+
     ;
 
     /**
@@ -91,6 +96,8 @@ public interface NativeCUESDK extends Library {
     byte CorsairSetLedsColorsBufferByDeviceIndex(int deviceIndex, int size, CorsairLedColor.CorsairLedColorStructure ledsColors);
 
     byte CorsairSetLedsColorsFlushBuffer();
+
+    byte CorsairSetLedsColorsFlushBufferAsync(CorsairSetLedsColorsFlushBufferAsync_callback_callback cb, Pointer context);
 
     /**
      * Original signature : <code>int CorsairGetDeviceCount()</code><br>


### PR DESCRIPTION
This PR adds the functions

`CorsairSetLedsColorsBufferByDeviceIndex`

and the
`CorsairSetLedsColorsFlushBuffer` (and it's asynchronous counterpart) 

These are used in the new iCUE SDK examples and might help fix some issues
